### PR TITLE
Fix errors for reponse with different type of keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,13 +69,16 @@ function wrapClientMethods(client, wrapper, options, operation){
             if(typeof client[operation] === 'undefined'){reject('Invalid operation: '+operation)}
             client[operation](getRequestMessage(options, operation, params), function(err, response){
                 if(err){console.error(err);return}
-                var keys = Object.keys(response);
-                var responseResult = keys[1];
-                //Catch response errors:
-                var requestMade = response[responseResult][0].Request;
+                var keys = Object.keys(response),
+                responseResult = keys[0],
+                requestMade = response[responseResult];
+                if(keys[1]){
+                    responseResult = keys[1];
+                    requestMade = response[responseResult][0].Request;
+                }
                 if(requestMade.IsValid === "True"){
                     resolve(response);
-                } else {
+                } else { //Catch response errors:
                     var message = operation+" - "+requestMade.Errors.Error[0].Message;
                     var error = new Error(message);
                     reject(error);


### PR DESCRIPTION
Current api assume the access id / key setup correctly, Which expects keys of response are always in an array (length>1) i.e.  keys == ["OperationRequest","GetAccountBalanceResult"]  , and response[keys[1]] looks like: 
```
	{
		"OperationRequest": {
			"RequestId": "c9732e78-c104-40f2-b395-fcd8233b9eb2"
		},
		"GetAccountBalanceResult": [{
			"Request": {
				"IsValid": "True"
			},
			"AvailableBalance": {
				"Amount": "10000.000",
				"CurrencyCode": "USD",
				"FormattedPrice": "$10,000.00"
			}
		}]
	}
```

However, here is another case (User might use an invalid access id/key), which returns  keys == ["OperationRequest"],  and response[keys[0]] like this:  
```
 	{
		"RequestId": "b1761c57-4ee9-4b14-b510-2b4690fc5d7f",
		"Errors": {
			"Error": [{
				"Code": "AWS.NotAuthorized",
				"Message": "The identity contained in the request is not authorized to use this AWSAccessKeyId (1459978277346 s)"
			}]
		}
	}
```



This fix basically handles both of those instead of crashing. It would be nice to fix this for ppl using this API in their apps.