### PR TITLE
Make request throttle configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ mturk.createClient(config).then(function(api){
   //if you exceed their request rate-limit, you will receive a
   //'503 Service Unavailable' response. As of v2.0, our interface
   //automatically throttles your requests to 3 per second.
+  //This limit can be modified by setting the environment variable MTURK_API_REQUEST_THROTTLE
   for(var i=0; i < 20; i++){
     //These requests will be queued and executed at a rate of 3 per second
     api.req('SearchHITs', { PageNumber: i }).then(function(res){

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var SERVICE = 'AWSMechanicalTurkRequester';
 //Throttles client requests to a  rate-limited 3 request per second,  makes sure mturk does not return
 //503 errors when it is overwhealmed by multiple simultaneous requests (by requests in a for loop, for example)
 var requestQueue = new PromiseThrottle({
-    requestsPerSecond: 3,           // up to 1 request per second
+    requestsPerSecond: parseInt(process.env.MTURK_API_REQUEST_THROTTLE) || 3,  //Default 3 request per second limit
     promiseImplementation: Promise  // the Promise library you are using
 });
 


### PR DESCRIPTION
I found the 3 requests per second to be a bit limiting, so I put that constant on an environment variable.

I thought about moving the queue instantiation into the client constructor, and reading the limit from the `config` object as a different solution.

Also, does anyone know at what threshold you will begin to get 503's from mturk?